### PR TITLE
Fix problem with "content" not being parsed on non-meta items

### DIFF
--- a/src/Jkphl/Micrometa/Parser/Microdata/Element.php
+++ b/src/Jkphl/Micrometa/Parser/Microdata/Element.php
@@ -304,6 +304,10 @@ class Element extends \DOMElement
                 }
 
             default:
+                $value=$this->getAttribute('content');
+                if (!empty($value)) {
+                    return $value;
+                }
 //              trigger_error(sprintf('Microdata parser: Unhandled tag name "%s"', $this->tagName), E_USER_WARNING);
                 return $this->textContent;
         }


### PR DESCRIPTION
Resolves https://github.com/jkphl/micrometa/issues/13 .